### PR TITLE
update example to point to spp.h, closes #1

### DIFF
--- a/R/package-sparsepp.R
+++ b/R/package-sparsepp.R
@@ -17,12 +17,14 @@
 #' \dontrun{
 #' library(Rcpp)
 #' code = "
+#' // [[Rcpp::plugins(cpp11)]]
 #' #include <Rcpp.h>
 #' using namespace std;
 #' using namespace Rcpp;
 #' // drop-in replacement for unordered_map
 #' //#include <unordered_map>
-#' #include <sparsepp.h>
+#' #include <sparsepp/spp.h>
+#' //[[Rcpp::depends(sparsepp)]]
 #' using spp::sparse_hash_map;
 #' // @export
 #' // [[Rcpp::export]]

--- a/man/sparsepp-package.Rd
+++ b/man/sparsepp-package.Rd
@@ -24,12 +24,14 @@ It aims to achieve the following objectives:
 \dontrun{
 library(Rcpp)
 code = "
+// [[Rcpp::plugins(cpp11)]]
 #include <Rcpp.h>
 using namespace std;
 using namespace Rcpp;
 // drop-in replacement for unordered_map
 //#include <unordered_map>
-#include <sparsepp.h>
+#include <sparsepp/spp.h>
+//[[Rcpp::depends(sparsepp)]]
 using spp::sparse_hash_map;
 // @export
 // [[Rcpp::export]]


### PR DESCRIPTION
Simple fix to the example code in the package man page....header file location is `sparsepp/spp.h`.